### PR TITLE
Move to Gradle dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
       </receiver>
     </config-file>
     <source-file src="src/android/CPGoogleAnalytics.java" target-dir="src/com/appfeel/cordova/analytics" />
-    <dependency id="cordova-google-play-services" />
+    <framework src="com.google.android.gms:play-services-analytics:+" />
   </platform>
   
   


### PR DESCRIPTION
I propose that you move to Gradle based dependency rather than a dependent
plugin. When you link in the other plugin it may cause multiple dexing issues
with other plugins.
